### PR TITLE
解决配置项添加输入框，只能输入一个框的值的问题

### DIFF
--- a/dlink-web/src/components/Studio/StudioRightTool/StudioSetting/index.tsx
+++ b/dlink-web/src/components/Studio/StudioRightTool/StudioSetting/index.tsx
@@ -38,7 +38,9 @@ const StudioSetting = (props: any) => {
     return itemList;
   };
 
-  form.setFieldsValue(current.task);
+  useEffect(()=>{
+    form.setFieldsValue(current.task);
+  },[])
 
   const onValuesChange = (change:any,all:any)=>{
     let newTabs = tabs;


### PR DESCRIPTION
解决配置项添加输入框，只能输入一个框的值的问题