### PR TITLE
[fixbug]修复生成的flinksqlDDL注释中存在单双引号引起语法校验失败的问题  优化DDL中字段添加`` 防止关键字问题造成校验失败

### DIFF
--- a/dlink-admin/src/test/java/com/dlink/admin/AdminTest.java
+++ b/dlink-admin/src/test/java/com/dlink/admin/AdminTest.java
@@ -15,15 +15,6 @@ public class AdminTest {
     public void adminTest(){
         String admin = SaSecureUtil.md5("admin");
         System.out.println(admin);
-
-        String str = "g'o\"od\"";
-        if(str.contains("\'") || str.contains("\"")) {
-            System.out.println (str.replaceAll("\"|'","***"));
-//            System.out.println(str.replaceAll("\"|\'", Matcher.quoteReplacement("***")));
-//            System.out.println(" COMMENT '"+ str.replaceAll("\"|'", Matcher.quoteReplacement("***")) + "'");
-        }
-
-
     }
 
 }

--- a/dlink-admin/src/test/java/com/dlink/admin/AdminTest.java
+++ b/dlink-admin/src/test/java/com/dlink/admin/AdminTest.java
@@ -15,6 +15,15 @@ public class AdminTest {
     public void adminTest(){
         String admin = SaSecureUtil.md5("admin");
         System.out.println(admin);
+
+        String str = "g'o\"od\"";
+        if(str.contains("\'") || str.contains("\"")) {
+            System.out.println (str.replaceAll("\"|'","***"));
+//            System.out.println(str.replaceAll("\"|\'", Matcher.quoteReplacement("***")));
+//            System.out.println(" COMMENT '"+ str.replaceAll("\"|'", Matcher.quoteReplacement("***")) + "'");
+        }
+
+
     }
 
 }

--- a/dlink-common/src/main/java/com/dlink/model/Table.java
+++ b/dlink-common/src/main/java/com/dlink/model/Table.java
@@ -81,7 +81,7 @@ public class Table implements Serializable, Comparable<Table> {
             if (i > 0) {
                 sb.append(",");
             }
-            sb.append(columns.get(i).getName() + " " + type);
+            sb.append("`" + columns.get(i).getName() + "` " + type);
             if (Asserts.isNotNullString(columns.get(i).getComment())) {
                 if(columns.get(i).getComment().contains("\'") | columns.get(i).getComment().contains("\"")) {
                     sb.append(" COMMENT '" + columns.get(i).getComment().replaceAll("\"|'","") + "'");
@@ -91,7 +91,7 @@ public class Table implements Serializable, Comparable<Table> {
             }
             sb.append("\n");
             if (columns.get(i).isKeyFlag()) {
-                pks.add(columns.get(i).getName());
+                pks.add("`"+columns.get(i).getName()+"`");
             }
         }
         StringBuilder pksb = new StringBuilder("PRIMARY KEY ( ");
@@ -99,7 +99,7 @@ public class Table implements Serializable, Comparable<Table> {
             if (i > 0) {
                 pksb.append(",");
             }
-            pksb.append(pks.get(i));
+            pksb.append("`"+pks.get(i)+"`");
         }
         pksb.append(" ) NOT ENFORCED\n");
         if (pks.size() > 0) {
@@ -133,9 +133,9 @@ public class Table implements Serializable, Comparable<Table> {
                 columnComment = columnComment.replaceAll("\"|'","");
             }
             if(Asserts.isNotNullString(columnComment)){
-                sb.append(columns.get(i).getName() + "  --  " + columnComment + " \n");
+                sb.append("`"+columns.get(i).getName() + "`  --  " + columnComment + " \n");
             }else {
-                sb.append(columns.get(i).getName() + " \n");
+                sb.append("`"+columns.get(i).getName() + "` \n");
 
             }
         }

--- a/dlink-common/src/main/java/com/dlink/model/Table.java
+++ b/dlink-common/src/main/java/com/dlink/model/Table.java
@@ -83,7 +83,7 @@ public class Table implements Serializable, Comparable<Table> {
             }
             sb.append(columns.get(i).getName() + " " + type);
             if (Asserts.isNotNullString(columns.get(i).getComment())) {
-                if(columns.get(i).getComment().contains("\'") || columns.get(i).getComment().contains("\"")) {
+                if(columns.get(i).getComment().contains("\'") | columns.get(i).getComment().contains("\"")) {
                     sb.append(" COMMENT '" + columns.get(i).getComment().replaceAll("\"|'","") + "'");
                 }else {
                     sb.append(" COMMENT '" + columns.get(i).getComment() + "'");
@@ -108,7 +108,7 @@ public class Table implements Serializable, Comparable<Table> {
         }
         sb.append(")");
         if(Asserts.isNotNullString(comment)){
-            if(comment.contains("\'") || comment.contains("\"")) {
+            if(comment.contains("\'") | comment.contains("\"")) {
                 sb.append(" COMMENT '" + comment.replaceAll("\"|'","") + "'\n");
             }else {
                 sb.append(" COMMENT '" + comment + "'\n");
@@ -129,7 +129,7 @@ public class Table implements Serializable, Comparable<Table> {
             }
             String columnComment= columns.get(i).getComment();
 
-            if(columnComment.contains("\'") || columnComment.contains("\"")) {
+            if(columnComment.contains("\'") | columnComment.contains("\"")) {
                 columnComment = columnComment.replaceAll("\"|'","");
             }
             if(Asserts.isNotNullString(columnComment)){

--- a/dlink-common/src/main/java/com/dlink/model/Table.java
+++ b/dlink-common/src/main/java/com/dlink/model/Table.java
@@ -91,7 +91,7 @@ public class Table implements Serializable, Comparable<Table> {
             }
             sb.append("\n");
             if (columns.get(i).isKeyFlag()) {
-                pks.add("`"+columns.get(i).getName()+"`");
+                pks.add(columns.get(i).getName());
             }
         }
         StringBuilder pksb = new StringBuilder("PRIMARY KEY ( ");

--- a/dlink-common/src/main/java/com/dlink/model/Table.java
+++ b/dlink-common/src/main/java/com/dlink/model/Table.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -84,7 +83,11 @@ public class Table implements Serializable, Comparable<Table> {
             }
             sb.append(columns.get(i).getName() + " " + type);
             if (Asserts.isNotNullString(columns.get(i).getComment())) {
-                sb.append(" COMMENT '"+columns.get(i).getComment() + "'");
+                if(columns.get(i).getComment().contains("\'") || columns.get(i).getComment().contains("\"")) {
+                    sb.append(" COMMENT '" + columns.get(i).getComment().replaceAll("\"|'","") + "'");
+                }else {
+                    sb.append(" COMMENT '" + columns.get(i).getComment() + "'");
+                }
             }
             sb.append("\n");
             if (columns.get(i).isKeyFlag()) {
@@ -105,7 +108,11 @@ public class Table implements Serializable, Comparable<Table> {
         }
         sb.append(")");
         if(Asserts.isNotNullString(comment)){
-            sb.append(" COMMENT '"+comment+"'\n");
+            if(comment.contains("\'") || comment.contains("\"")) {
+                sb.append(" COMMENT '" + comment.replaceAll("\"|'","") + "'\n");
+            }else {
+                sb.append(" COMMENT '" + comment + "'\n");
+            }
         }
         sb.append(" WITH (\n");
         sb.append(getFlinkTableWith(flinkConfig));
@@ -120,9 +127,23 @@ public class Table implements Serializable, Comparable<Table> {
             if (i > 0) {
                 sb.append(",");
             }
-            sb.append(columns.get(i).getName() + "\n");
+            String columnComment= columns.get(i).getComment();
+
+            if(columnComment.contains("\'") || columnComment.contains("\"")) {
+                columnComment = columnComment.replaceAll("\"|'","");
+            }
+            if(Asserts.isNotNullString(columnComment)){
+                sb.append(columns.get(i).getName() + "  --  " + columnComment + " \n");
+            }else {
+                sb.append(columns.get(i).getName() + " \n");
+
+            }
         }
-        sb.append(" FROM " + catalogName + "." + schema + "." + name + ";\n");
+        if(Asserts.isNotNullString(comment)){
+            sb.append(" FROM " + catalogName + "." + schema + "." + name + ";" + " -- " + comment + "\n");
+        }else {
+            sb.append(" FROM " + catalogName + "." + schema + "." + name +";\n");
+        }
         return sb.toString();
     }
 }

--- a/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
+++ b/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
@@ -2,9 +2,6 @@ package com.dlink.metadata.driver;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
-import com.alibaba.druid.sql.parser.ParserException;
-import com.alibaba.druid.sql.parser.SQLStatementParser;
-import com.alibaba.druid.sql.parser.Token;
 import com.dlink.assertion.Asserts;
 import com.dlink.constant.CommonConstant;
 import com.dlink.metadata.query.IDBQuery;
@@ -17,13 +14,7 @@ import com.dlink.utils.LogUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.*;
 
 /**
@@ -160,13 +151,16 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
             results = preparedStatement.executeQuery();
             while (results.next()) {
                 Column field = new Column();
-                String columnName = results.getString(dbQuery.columnName());
+                String columnName = "`"+results.getString(dbQuery.columnName())+"`";
                 String key = results.getString(dbQuery.columnKey());
                 field.setKeyFlag(Asserts.isNotNullString(key) && Asserts.isEqualsIgnoreCase("PRI",key));
                 field.setName(columnName);
                 field.setType(results.getString(dbQuery.columnType()));
                 field.setJavaType(getTypeConvert().convert(field.getType()).getType());
-                field.setComment(results.getString(dbQuery.columnComment()));
+
+                String columnComment=results.getString(dbQuery.columnComment()).replaceAll("\"|'","");
+                field.setComment(columnComment);
+
                 field.setNullable(Asserts.isEqualsIgnoreCase(results.getString(dbQuery.isNullable()),"YES"));
                 field.setCharacterSet(results.getString(dbQuery.characterSet()));
                 field.setCollation(results.getString(dbQuery.collation()));

--- a/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
+++ b/dlink-metadata/dlink-metadata-base/src/main/java/com/dlink/metadata/driver/AbstractJdbcDriver.java
@@ -151,7 +151,7 @@ public abstract class AbstractJdbcDriver extends AbstractDriver {
             results = preparedStatement.executeQuery();
             while (results.next()) {
                 Column field = new Column();
-                String columnName = "`"+results.getString(dbQuery.columnName())+"`";
+                String columnName = results.getString(dbQuery.columnName());
                 String key = results.getString(dbQuery.columnKey());
                 field.setKeyFlag(Asserts.isNotNullString(key) && Asserts.isEqualsIgnoreCase("PRI",key));
                 field.setName(columnName);


### PR DESCRIPTION
[fixbug] 
修复生成的flinksqlDDL注释中存在单双引号引起语法校验失败的问题 
优化字段添加`` 防止关键字问题造成校验失败