### PR TITLE
fix(metadata):  MySqlDriver Flink Column Type Conversion error

### DIFF
--- a/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
+++ b/dlink-metadata/dlink-metadata-mysql/src/main/java/com/dlink/metadata/driver/MySqlDriver.java
@@ -45,7 +45,7 @@ public class MySqlDriver extends AbstractJdbcDriver {
     public Map<String, String> getFlinkColumnTypeConversion() {
         HashMap<String, String> map = new HashMap<>();
         map.put("VARCHAR", "STRING");
-        map.put("TEXY", "STRING");
+        map.put("TEXT", "STRING");
         map.put("INT", "INT");
         map.put("DATETIME", "TIMESTAMP");
         return map;


### PR DESCRIPTION
## Purpose of the pull request

This pull request  fix a mysql metadata error

## Brief change log

update mysqldriver. getFlinkColumnTypeConversion() method

