### PR TITLE
[Fix][web]  Fix the bug of beautifying "||" in the editor

### DIFF
--- a/dlink-web/src/components/Studio/StudioEdit/index.tsx
+++ b/dlink-web/src/components/Studio/StudioEdit/index.tsx
@@ -157,9 +157,10 @@ const FlinkSqlEditor = (props:any) => {
         var formatted = format(model.getValueInRange(range), {
           indent: ' '.repeat(options.tabSize)
         });
-        formatted = formatted.replace(/` ([^`]*) `/g,function (){return '`'+arguments[1].trim()+'`'})
-          .replace(/\$ {([^}]*)}/g,function (){return '${'+arguments[1].trim()+'}'})
-          .replace(/\| ([^}]*)\|/g,function (){return '|'+arguments[1].trim()+'|'})
+        formatted = formatted.replaceAll(/` ([^`]*) `/g,function (){return '`'+arguments[1].trim()+'`'})
+          .replaceAll(/\$ {([^}]*)}/g,function (){return '${'+arguments[1].trim()+'}'})
+          .replaceAll(/\| ([^}]*)\|/g,function (){return '|'+arguments[1].trim()+'|'})
+          .replaceAll(/ - /g,function (){return '-'});
         return [
           {
             range: range,


### PR DESCRIPTION
## Purpose of the pull request

Fix the bug of beautifying "||" in the editor

## Brief change log

## Verify this pull request
