### PR TITLE
[fix-239][core] Use "==" to judge whether the values of referenced variables are equal. Replace with the equals function.

### DIFF
--- a/dlink-core/src/main/java/com/dlink/explainer/ca/CABuilder.java
+++ b/dlink-core/src/main/java/com/dlink/explainer/ca/CABuilder.java
@@ -82,7 +82,7 @@ public class CABuilder {
         Set<NodeRel> columnCASRel = result.getColumnCASRel();
         boolean hasChildren = false;
         for (NodeRel nodeRel : columnCASRel) {
-            if (columnId == nodeRel.getSufId()) {
+            if (columnId.equals(nodeRel.getSufId())) {
                 ColumnCA childca = (ColumnCA) result.getColumnCASMaps().get(nodeRel.getPreId());
 //                operation = operation.replaceAll(childca.getAlias().replaceAll("\\$","\\\\$"),childca.getOperation());
                 operation = operation.replaceAll(childca.getAlias()

--- a/dlink-core/src/main/java/com/dlink/explainer/ca/ColumnCAGenerator.java
+++ b/dlink-core/src/main/java/com/dlink/explainer/ca/ColumnCAGenerator.java
@@ -61,7 +61,7 @@ public class ColumnCAGenerator implements CAGenerator {
                 }
                 for (int j = 0; j < this.columnCAS.size(); j++) {
                     ColumnCA columnCA = (ColumnCA) this.columnCAS.get(j);
-                    if (columnCA.getTableCA().getId() == tableCA.getId()) {
+                    if (columnCA.getTableCA().getId().equals(tableCA.getId())) {
                         buildColumnCAFields(tableCA, tableCA.getParentId(), columnCA);
                     }
                 }
@@ -118,7 +118,7 @@ public class ColumnCAGenerator implements CAGenerator {
         for (int i = 0; i < this.sourceTableCAS.size(); i++) {
             if (this.sourceTableCAS.get(i) instanceof TableCA) {
                 TableCA sourceTableCA = (TableCA) this.sourceTableCAS.get(i);
-                if (sourceTableCA.getId() == tableCA.getId()) {
+                if (sourceTableCA.getId().equals(tableCA.getId())) {
                     tableCA.setFields(sourceTableCA.getFields());
                 }
             }
@@ -148,7 +148,7 @@ public class ColumnCAGenerator implements CAGenerator {
             Integer cid = null;
             for (int j = 0; j < this.columnCAS.size(); j++) {
                 ColumnCA columnCA1 = (ColumnCA) this.columnCAS.get(j);
-                if (columnCA1.getTableCA().getId() == tableCA.getId() && columnCA1.getName().equals(alias)) {
+                if (columnCA1.getTableCA().getId().equals(tableCA.getId()) && columnCA1.getName().equals(alias)) {
                     isHad = true;
                     cid = columnCA1.getId();
                     break;

--- a/dlink-core/src/main/java/com/dlink/explainer/lineage/LineageColumnGenerator.java
+++ b/dlink-core/src/main/java/com/dlink/explainer/lineage/LineageColumnGenerator.java
@@ -68,7 +68,7 @@ public class LineageColumnGenerator {
 
     private void matchSinkField(TableCA tableCA) {
         for (ColumnCA columnCA : columnCAS) {
-            if (columnCA.getTableId() == tableCA.getId()) {
+            if (columnCA.getTableId().equals(tableCA.getId())) {
                 continue;
             }
             for (String fieldName : tableCA.getFields()) {
@@ -84,7 +84,7 @@ public class LineageColumnGenerator {
 
     private void buildColumnCAFields(TableCA tableCA, Integer id, ColumnCA columnCA) {
         if (transMaps.get(id) instanceof OperatorTrans) {
-            if (tableCA.getId() == id) {
+            if (tableCA.getId().equals(id)) {
                 return;
             }
             OperatorTrans trans = (OperatorTrans) transMaps.get(id);
@@ -115,13 +115,13 @@ public class LineageColumnGenerator {
             Integer cid = null;
             for (Map.Entry<Integer, ColumnCA> item : columnCASMaps.entrySet()) {
                 ColumnCA columnCA1 = item.getValue();
-                if (columnCA1.getTableCA().getId() == tableCA.getId() && columnCA1.getName().equals(alias)) {
+                if (columnCA1.getTableCA().getId().equals(tableCA.getId()) && columnCA1.getName().equals(alias)) {
                     isHad = true;
                     cid = columnCA1.getId();
                     break;
                 }
             }
-            if (columnCA.getId() == cid) {
+            if (columnCA.getId().equals(cid)) {
                 return;
             }
             if (!isHad) {
@@ -180,7 +180,7 @@ public class LineageColumnGenerator {
 
     private void buildSinkSuf(Integer preId, Integer sourcePreId) {
         for (NodeRel nodeRel : columnCASRel) {
-            if (nodeRel.getPreId() == preId) {
+            if (nodeRel.getPreId().equals(preId) ) {
                 Integer nextSufId = nodeRel.getSufId();
                 if (sinkColumns.contains(nextSufId)) {
                     columnCASRelChain.add(new NodeRel(sourcePreId, nextSufId));


### PR DESCRIPTION
## Purpose of the pull request
This pull request fix 239 bug : Use "==" to judge whether the values of referenced variables are equal.
<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log
Replace with the equals function as in below files, 
CABuilder.java
ColumnCAGenerator.java
LineageColumnGenerator.java
<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dlink-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
