### PR TITLE
[bugfix 370]避免因为特殊字符导致替换失败

### DIFF
--- a/dlink-executor/src/main/java/com/dlink/executor/SqlManager.java
+++ b/dlink-executor/src/main/java/com/dlink/executor/SqlManager.java
@@ -200,7 +200,8 @@ public final class SqlManager {
         while (m.find()) {
             String key = m.group(1);
             String value = this.getSqlFragment(key);
-            m.appendReplacement(sb, value == null ? "" : value);
+            m.appendReplacement(sb, "");
+            sb.append(value == null ? "" : value);
         }
         m.appendTail(sb);
         return sb.toString();


### PR DESCRIPTION
#370 

更改替换方法，避免特殊字符造成失败。