### PR TITLE
[Fix-426][metadata]修复clickhouse元数据不显示问题

### DIFF
--- a/dlink-metadata/dlink-metadata-clickhouse/src/main/java/com/dlink/metadata/driver/ClickHouseDriver.java
+++ b/dlink-metadata/dlink-metadata-clickhouse/src/main/java/com/dlink/metadata/driver/ClickHouseDriver.java
@@ -6,21 +6,17 @@ import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import com.alibaba.druid.sql.parser.ParserException;
 import com.alibaba.druid.sql.parser.Token;
-import com.dlink.assertion.Asserts;
 import com.dlink.metadata.ast.Clickhouse20CreateTableStatement;
 import com.dlink.metadata.convert.ClickHouseTypeConvert;
 import com.dlink.metadata.convert.ITypeConvert;
 import com.dlink.metadata.parser.Clickhouse20StatementParser;
 import com.dlink.metadata.query.ClickHouseQuery;
 import com.dlink.metadata.query.IDBQuery;
-import com.dlink.model.Schema;
 import com.dlink.model.Table;
 import com.dlink.result.SqlExplainResult;
 import com.dlink.utils.LogUtil;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -38,7 +34,8 @@ public class ClickHouseDriver extends AbstractJdbcDriver {
 
     @Override
     String getDriverClass() {
-        return "com.clickhouse.jdbc.ClickHouseDriver";
+//        return "com.clickhouse.jdbc.ClickHouseDriver";
+        return "ru.yandex.clickhouse.ClickHouseDriver";
     }
 
     @Override
@@ -59,56 +56,6 @@ public class ClickHouseDriver extends AbstractJdbcDriver {
     @Override
     public String getName() {
         return "ClickHouse OLAP 数据库";
-    }
-
-    @Override
-    public List<Schema> listSchemas() {
-        List<Schema> schemas = new ArrayList<>();
-        PreparedStatement preparedStatement = null;
-        ResultSet results = null;
-        String schemasSql = getDBQuery().schemaAllSql();
-        try {
-            preparedStatement = conn.prepareStatement(schemasSql);
-            results = preparedStatement.executeQuery();
-            while (results.next()) {
-                String schemaName= results.getMetaData().getSchemaName(0);
-                if (Asserts.isNotNullString(schemaName)) {
-                    Schema schema = new Schema(schemaName);
-                    schemas.add(schema);
-                }
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        } finally {
-            close(preparedStatement, results);
-        }
-        return schemas;
-    }
-
-    @Override
-    public List<Table> listTables(String schemaName) {
-        List<Table> tableList = new ArrayList<>();
-        PreparedStatement preparedStatement = null;
-        ResultSet results = null;
-        String sql = getDBQuery().tablesSql(schemaName);
-        try {
-            preparedStatement = conn.prepareStatement(sql);
-            results = preparedStatement.executeQuery();
-            while (results.next()) {
-                String tableName = results.getString(getDBQuery().tableName());
-                if (Asserts.isNotNullString(tableName)) {
-                    Table tableInfo = new Table();
-                    tableInfo.setName(tableName);
-                    tableInfo.setSchema(schemaName);
-                    tableList.add(tableInfo);
-                }
-            }
-        } catch (SQLException e) {
-            e.printStackTrace();
-        } finally {
-            close(preparedStatement, results);
-        }
-        return tableList;
     }
 
     @Override

--- a/dlink-metadata/dlink-metadata-clickhouse/src/main/java/com/dlink/metadata/query/ClickHouseQuery.java
+++ b/dlink-metadata/dlink-metadata-clickhouse/src/main/java/com/dlink/metadata/query/ClickHouseQuery.java
@@ -62,4 +62,9 @@ public class ClickHouseQuery extends AbstractDBQuery {
     public String isNullable() {
         return "NULL";
     }
+    
+    @Override
+    public String createTableName() {
+        return "statement";
+    }
 }

--- a/dlink-metadata/dlink-metadata-clickhouse/src/main/java/com/dlink/metadata/query/ClickHouseQuery.java
+++ b/dlink-metadata/dlink-metadata-clickhouse/src/main/java/com/dlink/metadata/query/ClickHouseQuery.java
@@ -9,7 +9,7 @@ package com.dlink.metadata.query;
 public class ClickHouseQuery extends AbstractDBQuery {
     @Override
     public String schemaAllSql() {
-        return "show databases";
+        return "SELECT currentDatabase()";
     }
 
     @Override
@@ -25,7 +25,7 @@ public class ClickHouseQuery extends AbstractDBQuery {
 
     @Override
     public String schemaName() {
-        return "db";
+        return "database";
     }
 
     @Override

--- a/dlink-metadata/dlink-metadata-clickhouse/src/main/java/com/dlink/metadata/query/ClickHouseQuery.java
+++ b/dlink-metadata/dlink-metadata-clickhouse/src/main/java/com/dlink/metadata/query/ClickHouseQuery.java
@@ -9,23 +9,35 @@ package com.dlink.metadata.query;
 public class ClickHouseQuery extends AbstractDBQuery {
     @Override
     public String schemaAllSql() {
-        return "SELECT currentDatabase()";
+        return "show databases";
     }
 
+    /**
+     * 获取模式名称下的所有表，从元数据表中获取获取
+     *
+     * @param schemaName 模式名称
+     * @return String
+     */
     @Override
     public String tablesSql(String schemaName) {
-        return "show tables";
+        return "select name from system.tables where 1=1 and database='" + schemaName + "'";
     }
 
-
+    /**
+     * 从元数据表中获取表字段信息
+     *
+     * @param schemaName 模式名称
+     * @param tableName  表名
+     * @return String
+     */
     @Override
     public String columnsSql(String schemaName, String tableName) {
-        return "desc `" + tableName + "`";
+        return "select  * from system.columns where 1=1 and database='" + schemaName + "' and table='" + tableName + "'";
     }
 
     @Override
     public String schemaName() {
-        return "database";
+        return "name";
     }
 
     @Override
@@ -55,16 +67,21 @@ public class ClickHouseQuery extends AbstractDBQuery {
 
     @Override
     public String columnKey() {
-        return "KEY";
+        return "is_in_primary_key";
     }
 
     @Override
     public String isNullable() {
         return "NULL";
     }
-    
+
     @Override
     public String createTableName() {
         return "statement";
+    }
+
+    @Override
+    public String isPK() {
+        return "1";
     }
 }

--- a/dlink-metadata/dlink-metadata-clickhouse/src/test/java/com/dlink/metadata/ClickHouseTest.java
+++ b/dlink-metadata/dlink-metadata-clickhouse/src/test/java/com/dlink/metadata/ClickHouseTest.java
@@ -1,0 +1,67 @@
+package com.dlink.metadata;
+
+import com.dlink.metadata.driver.ClickHouseDriver;
+import com.dlink.metadata.driver.Driver;
+import com.dlink.metadata.driver.DriverConfig;
+import com.dlink.metadata.result.JdbcSelectResult;
+import com.dlink.model.Column;
+import com.dlink.model.Schema;
+import com.dlink.utils.JSONUtil;
+import com.fasterxml.jackson.databind.util.JSONPObject;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * ClickhouseTest
+ *
+ * @author heyang
+ * @since 2022/4/21 1:06
+ **/
+public class ClickHouseTest {
+
+    private static final String IP = "127.0.0.1";
+    private static String url="jdbc:clickhouse://"+IP+":8123/default";
+    private ClickHouseDriver clickHouseDriver = new ClickHouseDriver();
+    public Driver getDriver() {
+        DriverConfig config = new DriverConfig();
+        config.setType(clickHouseDriver.getType());
+        config.setName(clickHouseDriver.getName());
+        config.setIp(IP);
+        config.setPort(8123);
+//        config.setUsername(null);
+//        config.setPassword(null);
+        config.setUrl(url);
+        return Driver.build(config);
+    }
+
+    @Test
+    public void connectTest() {
+        String test = getDriver().test();
+        System.out.println(test);
+        System.out.println("end...");
+    }
+
+    @Test
+    public void schemaTest() {
+        List<Schema> schemasAndTables = getDriver().getSchemasAndTables();
+        System.out.println(JSONUtil.toJsonString(schemasAndTables));
+        System.out.println("end...");
+    }
+
+    @Test
+    public void columnTest() {
+        Driver driver = getDriver();
+        List<Column> columns = driver.listColumns("xxx", "xxx");
+        System.out.println(JSONUtil.toJsonString(columns));
+        System.out.println("end...");
+    }
+
+    @Test
+    public void queryTest() {
+        Driver driver = getDriver();
+        JdbcSelectResult query = driver.query("select * from xxx", 10);
+        System.out.println(JSONUtil.toJsonString(query));
+        System.out.println("end...");
+    }
+}


### PR DESCRIPTION
## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

修复clickhouse元数据信息不显示问题
## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
1：修改元数据获取方式为从系统表中获取，修复跨schema看查看建表语句功能。
## Verify this pull request
<!--*(Please pick either of the following options)*-->
1：添加clickhouse数据源
2：在元数据管理中查看clickhouse数据源，元数据是否正确显示。
This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dlink-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
