### PR TITLE
[Fix]batch execution with yarn-app mode using the useBatchModel param…

### DIFF
--- a/dlink-app/dlink-app-base/src/main/java/com/dlink/app/flinksql/Submiter.java
+++ b/dlink-app/dlink-app-base/src/main/java/com/dlink/app/flinksql/Submiter.java
@@ -41,7 +41,7 @@ public class Submiter {
         }
         return "select id, name, alias as jobName, type,check_point as checkpoint," +
                 "save_point_path as savePointPath, parallelism,fragment as useSqlFragment,statement_set as useStatementSet,config_json as config," +
-                " env_id as envId from dlink_task where id = " + id;
+                " env_id as envId,batch_model AS useBatchModel from dlink_task where id = " + id;
     }
 
     private static String getFlinkSQLStatement(Integer id, DBConfig config) {

--- a/dlink-executor/src/main/java/com/dlink/executor/AppBatchExecutor.java
+++ b/dlink-executor/src/main/java/com/dlink/executor/AppBatchExecutor.java
@@ -18,7 +18,7 @@ public class AppBatchExecutor extends Executor {
         this.executorSetting = executorSetting;
         if (Asserts.isNotNull(executorSetting.getConfig())) {
             Configuration configuration = Configuration.fromMap(executorSetting.getConfig());
-            this.environment = StreamExecutionEnvironment.createLocalEnvironment(configuration);
+            this.environment = StreamExecutionEnvironment.getExecutionEnvironment(configuration);
         } else {
             this.environment = StreamExecutionEnvironment.createLocalEnvironment();
         }


### PR DESCRIPTION
…eter

## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->
To solve the problem that dlink-app cannot submit a job with yarn-application mode.

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
I modify the sql, selecting parameter from the table dlink_task in mysql describing the details of one task, missing field batch_model. I added it. And the another one in AppBatchExecutor.java to solve the problem of 

_The LocalStreamEnvironment cannot be used when submitting a program through a client, or running in a TestEnvironment context._

## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dlink-core tests for end-to-end.*
  - *Added UDFUtilTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
