### PR TITLE
Fix flinkLibPath in K8S configuration is null  && fix cluster-id in test k8s-cluster-config is null

### DIFF
--- a/dlink-admin/src/main/java/com/dlink/service/impl/ClusterConfigurationServiceImpl.java
+++ b/dlink-admin/src/main/java/com/dlink/service/impl/ClusterConfigurationServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * ClusterConfigServiceImpl
@@ -68,6 +69,9 @@ public class ClusterConfigurationServiceImpl extends SuperServiceImpl<ClusterCon
             }
             if (kubernetesConfig.containsKey("kubernetes.cluster-id")) {
                 gatewayConfig.getFlinkConfig().getConfiguration().put("kubernetes.cluster-id", kubernetesConfig.get("kubernetes.cluster-id").toString());
+            }else{
+                //初始化FlinkKubeClient需要CLUSTER_ID,先用UUID代替，后面使用job名称来作为CLUSTER_ID
+                gatewayConfig.getFlinkConfig().getConfiguration().put("kubernetes.cluster-id", UUID.randomUUID().toString());
             }
             if (kubernetesConfig.containsKey("kubernetes.container.image")) {
                 gatewayConfig.getFlinkConfig().getConfiguration().put("kubernetes.container.image", kubernetesConfig.get("kubernetes.container.image").toString());

--- a/dlink-core/src/main/java/com/dlink/job/JobConfig.java
+++ b/dlink-core/src/main/java/com/dlink/job/JobConfig.java
@@ -168,9 +168,7 @@ public class JobConfig {
                 config.get("flinkLibPath").toString(),
                 config.get("hadoopConfigPath").toString()));
         } else {
-            gatewayConfig.setClusterConfig(ClusterConfig.build(config.get("flinkConfigPath").toString(),
-                config.get("flinkLibPath").toString(),
-                ""));
+            gatewayConfig.setClusterConfig(ClusterConfig.build(config.get("flinkConfigPath").toString()));
         }
         AppConfig appConfig = new AppConfig();
         if (config.containsKey("userJarPath") && Asserts.isNotNullString((String) config.get("userJarPath"))) {


### PR DESCRIPTION
这个PR和之前的issue:#556，pr:#561是不同的。之前的是在配置中心-集群配置管理-新建集群信息，在保存集群信息时报错，找不到flinkLibpath，报空指针错误。
这个PR是集群配置成功之后，编写flink sql任务，使用flink on k8s 的application模式，远程提交到k8s上的时候，找不到flinkLibpath报的空指针错误。使用的dlinky版本0.6.4。

[fix cluster-id in test k8s-cluster-config is null]
注册中心-集群配置管理，新建flink on k8s的集群配置，点击测试，报错空指针异常。原因是因为构建flinkkubeClient需要有kubernetes.cluster-id配置，默认生成UUID作为kubernetes.cluster-id，使用的dlinky版本0.6.4。