### PR TITLE
修复重新启动任务时，不能杀掉旧任务，导致会提交重复任务的问题

### DIFF
--- a/dlink-admin/src/main/java/com/dlink/service/impl/TaskServiceImpl.java
+++ b/dlink-admin/src/main/java/com/dlink/service/impl/TaskServiceImpl.java
@@ -497,7 +497,7 @@ public class TaskServiceImpl extends SuperServiceImpl<TaskMapper, Task> implemen
         jobConfig.setTaskId(jobInstance.getTaskId());
         JobManager jobManager = JobManager.build(jobConfig);
         jobManager.setUseGateway(useGateway);
-        if ("canceljob".equals(savePointType)) {
+        if (SavePointType.CANCEL.getValue().equals(savePointType)) {
             return jobManager.cancel(jobId);
         }
         SavePointResult savePointResult = jobManager.savepoint(jobId, savePointType, null);


### PR DESCRIPTION
运维中心-重新启动 ，重新启动任务时，不会杀掉旧任务，进而再重新启动任务，会导致同时启动多份任务